### PR TITLE
Connection as a context manager

### DIFF
--- a/remoto/connection.py
+++ b/remoto/connection.py
@@ -13,6 +13,13 @@ class Connection(object):
         self.logger = logger or FakeRemoteLogger()
         self.sudo = sudo
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.exit()
+        return False
+
     def execute(self, function, **kw):
         return self.gateway.remote_exec(function, **kw)
 


### PR DESCRIPTION
I'd like to use `remoto.Connection` as a context manager so I can do things like:

``` python
with remoto.Connection('example.com') as conn:
    run(conn, ['ls', '-la'])
```

This simple addition will let me do that.
