### PR TITLE
ship the LICENSE file in the distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include setup.py
+include LICENSE
 include README.rst
 include vendor.py


### PR DESCRIPTION
The purpose of this pull request is to ensure that the `LICENSE` file is distributed in the tarball on PyPI.

In the case of remoto's MIT license, all derivative copies of remoto are required to contain the disclaimer text within the MIT license (as described in the sentence "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.")

The license text is already included in the Git repository, and in order to ease development and distribution of remoto, it makes sense to simply include the license text in the python package on PyPI as well.