### PR TITLE
include tests in distribution package tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include setup.py
 include LICENSE
 include README.rst
 include vendor.py
+recursive-include remoto/tests *


### PR DESCRIPTION
Prior to this change, the `remoto/tests/` directory was present in Git, but not present in the release tarballs we shipped on PyPI.

Discussed this with Travis and Alfredo in #ceph-devel today. Alfredo pointed out that the reason the remoto tarball does not include the tests directory is that there is no `__init__.py` file there for distutils to find.

The solution Alfredo recommends is to add the directory to `MANIFEST.in`. With this change, the tests directory is present in the source package tarball.

The purpose of including the tests in the distribution is to 1) be consistent with what we're doing with the ceph-deploy package, and 2) make the tests easily available to run during the RPM builds.