### PR TITLE
Fix output splitting for Python 3

### DIFF
--- a/remoto/process.py
+++ b/remoto/process.py
@@ -139,8 +139,8 @@ def _remote_check(channel, cmd, **kw):
     process = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kw
     )
-    stdout = [line.strip('\n') for line in process.stdout.readlines()]
-    stderr = [line.strip('\n') for line in process.stderr.readlines()]
+    stdout = process.stdout.read().splitlines()
+    stderr = process.stderr.read().splitlines()
     channel.send((stdout, stderr, process.wait()))
 
 


### PR DESCRIPTION
This change fixes 2 problems:

- `line` is `bytes` here, so `strip(str)` fails on it.
- *execnet*'s serialization [breaks on Python 3](https://github.com/alfredodeza/execnet/issues/2) when list comprehensions are involved

The memory usage doesn't rise because the output was read into memory in its entirety anyway.

The splitting behavior stays the same:

```python
>>> import io
>>> tests = ['', 'a', 'a\nb', 'a\nb\n', 'a\n\n']
>>> for test in tests:
...     lines = io.StringIO(test).readlines()
...     print([line.strip('\n') for line in lines])
...     print(test.splitlines())
... 
[]
[]
['a']
['a']
['a', 'b']
['a', 'b']
['a', 'b']
['a', 'b']
['a', '']
['a', '']
```

The problem was encountered in https://github.com/ceph/ceph-deploy/pull/388#issuecomment-194008616