### PR TITLE
Allow selecting the remote Python version (or choose automatically)

### DIFF
--- a/remoto/connection.py
+++ b/remoto/connection.py
@@ -26,9 +26,11 @@ class Connection(object):
             self.gateway = self._make_gateway(hostname)
 
     def _make_gateway(self, hostname):
-        return execnet.makegateway(
+        gateway = execnet.makegateway(
             self._make_connection_string(hostname)
         )
+        gateway.reconfigure(py2str_as_py3str=False, py3str_as_py2str=False)
+        return gateway
 
     def _detect_sudo(self, _execnet=None):
         """

--- a/remoto/log.py
+++ b/remoto/log.py
@@ -12,6 +12,8 @@ def reporting(conn, result, timeout=None):
         try:
             received = result.receive(timeout)
             level_received, message = list(received.items())[0]
+            if not isinstance(message, str):
+                message = message.decode('utf-8')
             log_map[level_received](message.strip('\n'))
         except EOFError:
             break


### PR DESCRIPTION
This is needed because if remoto runs on Python 3, it still calls `python` (Python 2) on the remote machine, usually causing a mess.

Needed for https://github.com/ceph/ceph-deploy/pull/388