### PR TITLE
Clarify the error when Python is missing on a remote host

### DIFF
--- a/remoto/connection.py
+++ b/remoto/connection.py
@@ -21,9 +21,16 @@ class Connection(object):
         self.interpreter = interpreter or 'python%s' % sys.version_info[0]
 
         if eager:
-            if detect_sudo:
-                self.sudo = self._detect_sudo()
-            self.gateway = self._make_gateway(hostname)
+            try:
+                if detect_sudo:
+                    self.sudo = self._detect_sudo()
+                self.gateway = self._make_gateway(hostname)
+            except OSError:
+                self.logger.error(
+                    "Can't communicate with remote host, possibly because "
+                    "%s is not installed there" % self.interpreter
+                )
+                raise
 
     def _make_gateway(self, hostname):
         gateway = execnet.makegateway(


### PR DESCRIPTION
The output now looks like this (line 3 is new):

```
[ceph_deploy.install][DEBUG ] Detecting platform for host node2 ...
bash: python3: command not found
[node2][ERROR ] Can't communicate with remote host, possibly because python3 is not installed there
[ceph_deploy][ERROR ] RuntimeError: connecting to host: node2 resulted in errors: OSError cannot send (already closed?)
```