### PR TITLE
enhance log

### DIFF
--- a/remoto/log.py
+++ b/remoto/log.py
@@ -14,7 +14,7 @@ def reporting(conn, result, timeout=None):
             level_received, message = list(received.items())[0]
             if not isinstance(message, str):
                 message = message.decode('utf-8')
-            log_map[level_received](message.strip('\n'))
+            log_map[level_received](message.strip('\r\n'))
         except EOFError:
             break
         except Exception as err:

--- a/remoto/tests/test_log.py
+++ b/remoto/tests/test_log.py
@@ -36,6 +36,30 @@ class TestReporting(object):
         message = conn.logger.error.call_args[0][0]
         assert message == 'an error message'
 
+    def test_strip_new_line(self):
+        conn = Mock()
+        result = Mock()
+        result.receive.side_effect = [{'error': 'an error message\n'}, EOFError]
+        log.reporting(conn, result)
+        message = conn.logger.error.call_args[0][0]
+        assert message == 'an error message'
+
+    def test_strip_new_line_and_carriage_return(self):
+        conn = Mock()
+        result = Mock()
+        result.receive.side_effect = [{'error': 'an error message\r\n'}, EOFError]
+        log.reporting(conn, result)
+        message = conn.logger.error.call_args[0][0]
+        assert message == 'an error message'
+
+    def test_strip_return(self):
+        conn = Mock()
+        result = Mock()
+        result.receive.side_effect = [{'error': 'an error message\r'}, EOFError]
+        log.reporting(conn, result)
+        message = conn.logger.error.call_args[0][0]
+        assert message == 'an error message'
+
     def test_timeout_error(self):
         conn = Mock()
         result = Mock()


### PR DESCRIPTION
In some special case, the terminal will add extra line-end flag (\r and \n) when output the information.
Enhance the log function to strip both the line-end flag and clean the log.