### PR TITLE
better packaging for tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ include setup.py
 include LICENSE
 include README.rst
 include vendor.py
-recursive-include remoto/tests *


### PR DESCRIPTION
The `MANIFEST.in` approach can accidentally capture files we don't want (like py3's `__pycache__` directories). Also, it doesn't make `python setup.py build` copy the tests to the destination `build/` directory.

Debian's [Pybuild](https://wiki.debian.org/Python/Pybuild) system expects to be able to run the tests from the `build/` directory. In other words, this change makes it easier to package remoto for Debian.