### PR TITLE
tests: use absolute import for fake_module

### DIFF
--- a/remoto/tests/test_connection.py
+++ b/remoto/tests/test_connection.py
@@ -2,7 +2,7 @@ import sys
 from mock import Mock, patch
 from py.test import raises
 from remoto import connection
-import fake_module
+from . import fake_module
 
 
 class FakeSocket(object):


### PR DESCRIPTION
Prior to this change, Python 3 raised an `ImportError` on the relative import here. Switch to an absolute import to resolve this.