### PR TITLE
drop vendor directories from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,3 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
-
-# vendor
-remoto/lib/vendor/execnet
-execnet


### PR DESCRIPTION
Prior to this change, the execnet vendoring directories were hidden from Git. This could lead to the vendor'd execnet still being published from old Git clones (in fact this happened for the 0.0.30 release on PyPI).

Drop the .gitignores to make it more obvious that we need to clean up these files.