### PR TITLE
Continuous output from remote functions

### DIFF
--- a/remoto/connection.py
+++ b/remoto/connection.py
@@ -135,7 +135,7 @@ class ModuleExecute(object):
             self.channel.send("%s(%s)" % (name, arguments))
             try:
                 for item in self.channel:
-                    if item is None:
+                    if item is not None:
                         yield item
                     else:
                         self.channel.close()


### PR DESCRIPTION
So far, I've only used a pretty trivial implementation that accepts continuous output from a remote module. Duplicated wrapper to differentiate upon a set parameter `self.continuous` to not break previous implementations.

Remote module used `foo.py`:
```python
def test():
    for i in range(1, 10):
        channel.send(i)
    channel.send(None)

if __name__ == '__channelexec__':
    for item in channel:
        eval(item)
```

Solves #38 