### PR TITLE
Fix extend_path() to extend_env().

### DIFF
--- a/remoto/process.py
+++ b/remoto/process.py
@@ -160,7 +160,7 @@ def check(conn, command, exit=False, timeout=None, **kw):
     if not kw.get('env'):
         # get the remote environment's env so we can explicitly add
         # the path without wiping out everything
-        kw = extend_path(conn, kw)
+        kw = extend_env(conn, kw)
 
     conn.logger.info('Running command: %s' % ' '.join(admin_command(conn.sudo, command)))
     result = conn.execute(_remote_check, cmd=command, **kw)


### PR DESCRIPTION
Commit d8b8ebacccf7 changed extend_path() to extend_env(), but missed a
spot. This fixes it.

Signed-off-by: Chris Dunlop <chris@onthe.net.au>