### PR TITLE
README: mention ceph-medic as a consumer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,9 @@ bare minimum to handle easy logging and connections from the remote end.
 
 ``remoto`` is a bit opinionated as it was conceived to replace helpers and
 remote utilities for ``ceph-deploy``, a tool to run remote commands to configure
-and setup the distributed file system Ceph.
+and setup the distributed file system Ceph. `ceph-medic
+<https://pypi.org/project/ceph-medic/>`_ uses remoto as well to inspect Ceph
+clusters.
 
 
 Example Usage


### PR DESCRIPTION
In addition to ceph-deploy, ceph-medic is another user of remoto. Let's advertise this in the README.