### PR TITLE
Add has_connection to BaseConnection

### DIFF
--- a/remoto/backends/__init__.py
+++ b/remoto/backends/__init__.py
@@ -133,6 +133,11 @@ class BaseConnection(object):
             self.remote_module = LegacyModuleExecute(self.gateway, module, self.logger)
         return self.remote_module
 
+    def has_connection(self):
+        if self.gateway:
+            return self.gateway.hasreceiver()
+        return False
+
 
 class LegacyModuleExecute(object):
     """


### PR DESCRIPTION
If the other end of a connection dies it would be good to have a way to
check if it's still alive without having to send a command and catch an
error.

This patch adds a `has_connection` method to `BaseConnection`. We want
to use it in the ceph orchestrator to be able to check the state of the
connection for longer lived health checks.

Signed-off-by: Matthew Oliver <moliver@suse.com>