### PR TITLE
Always use communicate vs. read to interact with subprocess pipe in process._remote_check

### DIFF
--- a/remoto/process.py
+++ b/remoto/process.py
@@ -150,8 +150,7 @@ def _remote_check(channel, cmd, **kw):
             stdin.encode('utf-8', errors='ignore')
         stdout_stream, stderr_stream = process.communicate(stdin)
     else:
-        stdout_stream = process.stdout.read()
-        stderr_stream = process.stderr.read()
+        stdout_stream, stderr_stream = process.communicate()
 
     try:
         stdout_stream = stdout_stream.decode('utf-8')


### PR DESCRIPTION
Fixes #62 

This bug is the root cause of https://tracker.ceph.com/issues/50526