### PR TITLE
use unittest.mock on py3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Build-Depends:
  dh-python,
  python3,
  python3-execnet,
- python3-mock,
  python3-pytest,
  python3-setuptools,
 Standards-Version: 4.2.1

--- a/remoto/tests/backends/test_backends.py
+++ b/remoto/tests/backends/test_backends.py
@@ -1,5 +1,8 @@
 import sys
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 import pytest
 from remoto import backends
 from remoto.backends import local

--- a/remoto/tests/test_log.py
+++ b/remoto/tests/test_log.py
@@ -1,7 +1,10 @@
 from pytest import raises
 from remoto import log
 from remoto.exc import TimeoutError
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 
 class TestReporting(object):

--- a/remoto/tests/test_process.py
+++ b/remoto/tests/test_process.py
@@ -1,5 +1,7 @@
-from mock import Mock
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 from remoto import process
 import subprocess
 

--- a/remoto/tests/test_rsync.py
+++ b/remoto/tests/test_rsync.py
@@ -1,4 +1,7 @@
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 from remoto import file_sync
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,5 @@ envlist =  py27, py33, py36, py37
 [testenv]
 deps =
     pytest
-    mock
+    py26,py27: mock
 commands = py.test -v remoto/tests


### PR DESCRIPTION
`unittest.mock` is in stdlib on Python 3.3+. Use the non-stdlib mock package on older Python versions.